### PR TITLE
修改work详细页只加载一次的问题

### DIFF
--- a/src/main/java/cn/luischen/utils/Commons.java
+++ b/src/main/java/cn/luischen/utils/Commons.java
@@ -451,7 +451,8 @@ public class Commons {
                     System.out.println(data);
                     // //匹配src
                     Matcher m = Pattern.compile("src\\s*=\\s*\'?\"?(.*?)(\'|\"|>|\\s+)").matcher(data);
-                    if (m.find()) {
+                    while (m.find()){
+				 //  if (m.find()) {
                         rs.add(m.group(1));
                     }
                 }


### PR DESCRIPTION
修改了 \src\main\java\cn\luischen\utils 下Commons.java的代码 解决只加载一张图片的问题
``` java
   while (m_image.find()) {
                String data = m_image.group(1).trim();
                if(!"".equals(data) && data.contains("<img")) {
                    System.out.println(data);
                    // //匹配src
                    Matcher m = Pattern.compile("src\\s*=\\s*\'?\"?(.*?)(\'|\"|>|\\s+)").matcher(data);
                    while (m.find()){
//          此处的if 改为了while      if (m.find()) {
                        rs.add(m.group(1));
//                    }
                    }
                }
```
![](https://yfsql.oss-cn-beijing.aliyuncs.com/yf/Picture/mysite/mysitejietu6.png/logo)
